### PR TITLE
Add https:// to front of domain argument if it's not a URL

### DIFF
--- a/twofas_cli/twofas_cli.py
+++ b/twofas_cli/twofas_cli.py
@@ -62,7 +62,9 @@ def get(domain: str, identifier: str, api_base_url: str, ws_base_url: str):
     if identifier:
         domain = re.sub(r'[^a-zA-Z0-9 -.]', '', identifier.strip()).lower()
         domain = 'https://' + domain.replace(' ', '.') + '.2fa.invalid'
-
+    elif not re.match(r'https?://', domain):
+        domain = 'https://' + domain
+        
     api = TwoFasApi(api_base_url, ws_base_url)
     extension_id = get_extension_id()
     response = api.request2_fa_token(extension_id, domain)


### PR DESCRIPTION
The "domain" argument to the 2FAS API isn't actually expecting a domain, it's expecting a URL (see
https://github.com/twofas/2fas-server/issues/6).

Arguably it would be better to rename the "--domain" argument in this script to "--url" for clarity, but absent that, at the very least we should check if the user specifies a domain instead of a URL—since that's what the parameter is called, it's an easy mistake to make!—and if so, then add "https://" to the beginning of it so that we're passing the 2FAS server something it expects.

Fixes https://github.com/dspitzer/twofas-cli/issues/1.